### PR TITLE
Generalize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,41 @@
 FP_ecmwf_gfortran*
-*.o
-*_mod.mod
-class_gribfile.mod
 .DS_Store
 output
 FLEXPART
 FLEXPART_MPI
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Log files
+*.log


### PR DESCRIPTION
`*.o` is moved.
`*_mod.mod` and `class_gribfile.mod` are generalized by `*.mod`